### PR TITLE
Add an option to build with the accelerate framework that mirrors the

### DIFF
--- a/configure
+++ b/configure
@@ -43,6 +43,7 @@ UsageFull() {
   echo "    -nozlib    : Do not use zlib (gzip/zip)"
   echo "    -nonetcdf  : Do not use NetCDF"
   echo "    -nomathlib : Do not include routines which require ARPACK, LAPACK, or BLAS"
+  echo "    -macAccelerate : Use the Mac Accelerate framework for the math routines"
   echo ""
   echo "  EXPERIMENTAL OPTIONS:"
   echo "    -profile            : Use Gnu compiler profiling (>= V4.5)"
@@ -306,7 +307,7 @@ while [[ ! -z $1 ]] ; do
       CC=clang
       CXX=clang++
       FC=gfortran
-      OPTFLAGS="-O3 -Weverything"
+      OPTFLAGS="-O3 -Wall"
       OMPFLAGS=""
       FFLAGS="-ffree-form"
       FOPTFLAGS="-O3"
@@ -453,6 +454,12 @@ while [[ ! -z $1 ]] ; do
       ARPACK=""
       LAPACK=""
       BLAS=""
+      ;;
+    "-macAccelerate")
+      echo "Using Mac accelerate framework for math routines."
+      ARPACK=""
+      LAPACK=""
+      BLAS="-framework Accelerate"
       ;;
     "--with-bzlib"  )
       INCLUDE="$INCLUDE -I$VALUE/include"


### PR DESCRIPTION
corresponding Amber configure argument.

Also reduce -Weverything to -Wall (-Weverything is SOOOO verbose and brings down
Travis when it's used).
